### PR TITLE
 Removing the ContextualCheckBlock method from the validator (#1161)

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -256,9 +256,9 @@ namespace Stratis.Bitcoin.Features.Consensus
                     new BlockHeaderPowContextualRule(),
 
                     // rules that are inside the method ContextualCheckBlock
-                    new Bip113ActivationRule(),
-                    new Bip34ActivationRule(),
-                    new WitnessCommitmentsRule(),
+                    new TransactionLocktimeActivationRule(), // implements BIP113
+                    new CoinbaseHeighActivationRule(), // implements BIP34
+                    new WitnessCommitmentsRule(), // BIP141, BIP144
                     new BlockSizeRule(),
 
                     // rules that are inside the method CheckBlock
@@ -288,10 +288,12 @@ namespace Stratis.Bitcoin.Features.Consensus
                     new BlockHeaderPosContextualRule(),
 
                     // rules that are inside the method ContextualCheckBlock
-                    new Bip113ActivationRule(),
-                    new Bip34ActivationRule(),
-                    new WitnessCommitmentsRule(),
+                    new TransactionLocktimeActivationRule(), // implements BIP113
+                    new CoinbaseHeighActivationRule(), // implements BIP34
+                    new WitnessCommitmentsRule(), // BIP141, BIP144 
                     new BlockSizeRule(),
+
+                    new PosBlockContextRule(), // TODO: this rule needs to be implemented
 
                     // rules that are inside the method CheckBlock
                     new BlockMerkleRootRule(),

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusLoop.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusLoop.cs
@@ -453,8 +453,6 @@ namespace Stratis.Bitcoin.Features.Consensus
 
                 if (!context.SkipValidation)
                 {
-                    this.Validator.ContextualCheckBlock(context);
-
                     // Check the block itself.
                     this.Validator.CheckBlock(context);
                 }

--- a/src/Stratis.Bitcoin.Features.Consensus/Interfaces/IPowConsensusValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Interfaces/IPowConsensusValidator.cs
@@ -84,14 +84,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Interfaces
         uint256 ComputeMerkleRoot(List<uint256> leaves, out bool mutated);
 
         /// <summary>
-        /// Context-dependent validity checks.
-        /// </summary>
-        /// <param name="context">Context that contains variety of information regarding blocks validation and execution.</param>
-        /// <exception cref="ConsensusErrors.BadTransactionNonFinal">Thrown if one or more transactions are not finalized.</exception>
-        /// <exception cref="ConsensusErrors.BadCoinbaseHeight">Thrown if coinbase doesn't start with serialized block height.</exception>
-        void ContextualCheckBlock(RuleContext context);
-
-        /// <summary>
         /// Validates the UTXO set is correctly spent.
         /// </summary>
         /// <param name="context">Context that contains variety of information regarding blocks validation and execution.</param>

--- a/src/Stratis.Bitcoin.Features.Consensus/PosConsensusValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/PosConsensusValidator.cs
@@ -248,44 +248,6 @@ namespace Stratis.Bitcoin.Features.Consensus
             this.logger.LogTrace("(-)");
         }
 
-        /// <inheritdoc />
-        public override void ContextualCheckBlock(RuleContext context)
-        {
-            this.logger.LogTrace("()");
-
-            base.ContextualCheckBlock(context);
-
-            // TODO: fix this validation code
-
-            //// check proof-of-stake
-            //// Limited duplicity on stake: prevents block flood attack
-            //// Duplicate stake allowed only when there is orphan child block
-            //if (!fReindex && !fImporting && pblock->IsProofOfStake() && setStakeSeen.count(pblock->GetProofOfStake()) && !mapOrphanBlocksByPrev.count(hash))
-            //    return error("ProcessBlock() : duplicate proof-of-stake (%s, %d) for block %s", pblock->GetProofOfStake().first.ToString(), pblock->GetProofOfStake().second, hash.ToString());
-
-            //if (!BlockValidator.IsCanonicalBlockSignature(context.BlockResult.Block, false))
-            //{
-            //    //if (node != null && (int)node.Version >= CANONICAL_BLOCK_SIG_VERSION)
-            //    //node.Misbehaving(100);
-
-            //    //return false; //error("ProcessBlock(): bad block signature encoding");
-            //}
-
-            //if (!BlockValidator.IsCanonicalBlockSignature(context.BlockResult.Block, true))
-            //{
-            //    //if (pfrom && pfrom->nVersion >= CANONICAL_BLOCK_SIG_LOW_S_VERSION)
-            //    //{
-            //    //    pfrom->Misbehaving(100);
-            //    //    return error("ProcessBlock(): bad block signature encoding (low-s)");
-            //    //}
-
-            //    if (!BlockValidator.EnsureLowS(context.BlockResult.Block.BlockSignatur))
-            //        return false; // error("ProcessBlock(): EnsureLowS failed");
-            //}
-
-            this.logger.LogTrace("(-)[OK]");
-        }
-
         /// <summary>
         /// Checks whether the future drift should be reduced after provided timestamp.
         /// </summary>

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinbaseHeighRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinbaseHeighRule.cs
@@ -10,8 +10,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     /// </summary>
     /// <remarks>
     /// More info here https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki
-    /// </remarks>
-    public class Bip34Rule : ConsensusRule
+    /// </remarks>    
+    /// <exception cref="ConsensusErrors.BadCoinbaseHeight">Thrown if coinbase doesn't start with serialized block height.</exception>
+    public class CoinbaseHeighRule : ConsensusRule
     {
         /// <inheritdoc />
         public override Task RunAsync(RuleContext context)
@@ -55,7 +56,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     /// With Bitcoin the BIP34 was activated at block 227,835 using the deployment flags, 
     /// this rule allows a chain to have BIP34 activated as a deployment rule.
     /// </summary>
-    public class Bip34ActivationRule : Bip34Rule
+    public class CoinbaseHeighActivationRule : CoinbaseHeighRule
     {
         /// <inheritdoc />
         public override Task RunAsync(RuleContext context)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosBlockContextRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosBlockContextRule.cs
@@ -1,0 +1,44 @@
+﻿using System.Threading.Tasks;
+
+namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
+{
+    /// <summary>
+    /// Context checks on a POS block.
+    /// </summary>
+    public class PosBlockContextRule : PosConsensusRule
+    {
+        /// <inheritdoc />
+        public override Task RunAsync(RuleContext context)
+        {
+            // TODO: fix this validation code
+
+            //// check proof-of-stake
+            //// Limited duplicity on stake: prevents block flood attack
+            //// Duplicate stake allowed only when there is orphan child block
+            //if (!fReindex && !fImporting && pblock->IsProofOfStake() && setStakeSeen.count(pblock->GetProofOfStake()) && !mapOrphanBlocksByPrev.count(hash))
+            //    return error("ProcessBlock() : duplicate proof-of-stake (%s, %d) for block %s", pblock->GetProofOfStake().first.ToString(), pblock->GetProofOfStake().second, hash.ToString());
+
+            //if (!BlockValidator.IsCanonicalBlockSignature(context.BlockResult.Block, false))
+            //{
+            //    //if (node != null && (int)node.Version >= CANONICAL_BLOCK_SIG_VERSION)
+            //    //node.Misbehaving(100);
+
+            //    //return false; //error("ProcessBlock(): bad block signature encoding");
+            //}
+
+            //if (!BlockValidator.IsCanonicalBlockSignature(context.BlockResult.Block, true))
+            //{
+            //    //if (pfrom && pfrom->nVersion >= CANONICAL_BLOCK_SIG_LOW_S_VERSION)
+            //    //{
+            //    //    pfrom->Misbehaving(100);
+            //    //    return error("ProcessBlock(): bad block signature encoding (low-s)");
+            //    //}
+
+            //    if (!BlockValidator.EnsureLowS(context.BlockResult.Block.BlockSignatur))
+            //        return false; // error("ProcessBlock(): EnsureLowS failed");
+            //}
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/TransactionLocktimeActivationRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/TransactionLocktimeActivationRule.cs
@@ -12,7 +12,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     /// <remarks>
     /// More info here https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki
     /// </remarks>
-    public class Bip113ActivationRule : ConsensusRule
+    /// <exception cref="ConsensusErrors.BadTransactionNonFinal">Thrown if one or more transactions are not finalized.</exception>
+    public class TransactionLocktimeActivationRule : ConsensusRule
     {
         /// <inheritdoc />
         public override Task RunAsync(RuleContext context)

--- a/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
@@ -13,6 +13,7 @@ using Stratis.Bitcoin.Base.Deployments;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;
+using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
 using Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
@@ -345,8 +346,7 @@ namespace Stratis.Bitcoin.IntegrationTests
             Network.Main.Consensus.Options = new PowConsensusOptions();
             ConsensusSettings consensusSettings = new ConsensusSettings().Load(NodeSettings.Default());
             var validator = new PowConsensusValidator(Network.Main, new Checkpoints(Network.Main, consensusSettings), DateTimeProvider.Default, this.loggerFactory);
-            //validator.CheckBlockHeader(context);
-            validator.ContextualCheckBlock(context);
+            new WitnessCommitmentsRule().RunAsync(context).GetAwaiter().GetResult();
             validator.CheckBlock(context);
         }
     }


### PR DESCRIPTION
* Remove BIP34 rule from validator

* Transaction locktime rule.

* Remove witness validation code from validator

* Remove block size checks from validator

* Removing the ContextualCheckBlock method from the validator

* Remove attribute from pos context check

* Add BIP number next to rules that implement a BIP

* Act on review